### PR TITLE
Normalize number-folding

### DIFF
--- a/plover_stroke.py
+++ b/plover_stroke.py
@@ -186,6 +186,17 @@ class BaseStroke(int):
             return cls.from_steno(value)
         return cls.from_keys(value)
 
+    def has_number(self):
+        "returns true if the stroke has keys that can be replaced with numbers"
+        if self.NUMBER_KEY is None:
+            return False
+        v = int(self)
+        nm = self.KEY_TO_MASK[self.NUMBER_KEY]
+        return (
+            (v & self.NUMBER_MASK)
+            and v & nm and v != nm
+        )
+
     def isnumber(self):
         if self.NUMBER_KEY is None:
             return False
@@ -247,13 +258,14 @@ class BaseStroke(int):
             v &= ~m
 
     def __repr__(self):
-        isnumber = self.isnumber()
+        has_number = self.has_number()
         left = ''
         middle = ''
         right = ''
         for k in self:
-            if isnumber:
+            if has_number and self.KEY_TO_MASK[k] & self.NUMBER_MASK:
                 if k == self.NUMBER_KEY:
+                    left += k
                     continue
                 k = self.KEY_TO_NUMBER[k]
             l = k.replace('-', '')

--- a/test/test_stroke.py
+++ b/test/test_stroke.py
@@ -139,12 +139,14 @@ NEW_TESTS = (
         '#',
         0b00000000000000000000001,
         False,
+        False,
     ),
     (
         'T- -B -P S-',
         'S- T- -P -B',
         'ST-PB',
         0b00000011000000000000110,
+        False,
         False,
     ),
     (
@@ -153,12 +155,14 @@ NEW_TESTS = (
         'AOE',
         0b00000000000101100000000,
         False,
+        False,
     ),
     (
         '-Z *',
         '* -Z',
         '*Z',
         0b10000000000010000000000,
+        False,
         False,
     ),
     (
@@ -167,19 +171,22 @@ NEW_TESTS = (
         'R-R',
         0b00000000100000010000000,
         False,
+        False,
     ),
     (
         'S- -P O- # T-',
         '# S- T- O- -P',
-        '120-7',
+        '#120-7',
         0b00000001000001000000111,
+        True,
         True,
     ),
     (
         '1- 2- 0- -7',
         '# S- T- O- -P',
-        '120-7',
+        '#120-7',
         0b00000001000001000000111,
+        True,
         True,
     ),
     (
@@ -188,11 +195,29 @@ NEW_TESTS = (
         '-FL',
         0b00000100010000000000000,
         False,
+        False,
     ),
+    (
+        '-B H- #',
+        '# H- -B',
+        '#4-B',
+        # ZDSTGLBPRFUE*OARHWPKTS#
+        0b00000010000000001000001,
+        False,
+        True,
+    ),
+    (
+        'S- -D P- -Z -U -G -B K- -T T- -L # -S A- -F -P R- * W- O- H- -E -R',
+        '# S- T- K- P- W- H- R- A- O- * -E -U -F -R -P -B -L -G -T -S -D -Z',
+        '#12K3W4R50*EU6R7B8G9SDZ',
+        0b11111111111111111111111,
+        False,
+        True,
+    )
 )
 
-@pytest.mark.parametrize('in_keys, keys, rtfcre, value, isnumber', NEW_TESTS)
-def test_new(english_stroke_class, in_keys, keys, rtfcre, value, isnumber):
+@pytest.mark.parametrize('in_keys, keys, rtfcre, value, isnumber, has_number', NEW_TESTS)
+def test_new(english_stroke_class, in_keys, keys, rtfcre, value, isnumber, has_number):
     in_keys = in_keys.split()
     keys = keys.split()
     for init_arg in (in_keys, rtfcre, value):
@@ -201,6 +226,7 @@ def test_new(english_stroke_class, in_keys, keys, rtfcre, value, isnumber):
         assert s.keys() == keys
         assert s.isnumber() == isnumber
         assert str(s) == rtfcre
+        assert s.has_number() == has_number
 
 HASH_TESTS = (
     ('#',    0b00000000000000000000001),


### PR DESCRIPTION
This is one solution for benoit-pierre/plover_stroke#1

At least one version of CaseCAT normalizes `#H-B` to `#4-B`:

![15  /# /#* 6789 /#-RBGS 1234 /#1KWR /#3-B /#4-B /#K-78](https://user-images.githubusercontent.com/6712121/130025105-8bb61554-58dd-4bff-b8c5-ac37baebf17e.png)

> [thanks to Jen on the Plover Discord](https://discord.com/channels/136953735426473984/144999734254370816/877796324257439765)